### PR TITLE
Allow setting password for db connection options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 0.1.0
+
+* Added `password` option for database connection options

--- a/lib/pgbundle/database.rb
+++ b/lib/pgbundle/database.rb
@@ -7,10 +7,12 @@ module PgBundle
   # on a typical environment ssh access is needed if the database host differs from
   # the Pgfile host
   class Database
-    attr_accessor :name, :user, :host, :system_user, :use_sudo, :port, :force_ssh
+    attr_accessor :name, :user, :password, :host, :system_user, :use_sudo, :port, :force_ssh
+
     def initialize(name, opts = {})
       @name        = name
       @user        = opts[:user]        || 'postgres'
+      @password    = opts[:password]
       @host        = opts[:host]        || 'localhost'
       @use_sudo    = opts[:use_sudo]    || false
       @system_user = opts[:system_user] || 'postgres'
@@ -21,8 +23,18 @@ module PgBundle
 
     def connection
       @connection ||= begin
-        PG.connect(dbname: name, user: user, host: host, port: port)
+        PG.connect(connection_opts)
       end
+    end
+
+    def connection_opts
+      {
+        dbname: name,
+        user: user,
+        password: password,
+        host: host,
+        port: port
+      }.compact
     end
 
     def to_s

--- a/lib/pgbundle/version.rb
+++ b/lib/pgbundle/version.rb
@@ -1,3 +1,3 @@
 module Pgbundle
-  VERSION = '0.0.17'
+  VERSION = '0.1.0'
 end


### PR DESCRIPTION
Fixes #25

This PR adds support for setting password for db connection options. This is required for running `pgbundle` command in a docker environment, since password is now required in official postgres docker images. (https://hub.docker.com/_/postgres)

Version changes from 0.0.17 to 0.1.0